### PR TITLE
Adds focus trap mechanism for when the datepicker is displayed in a popover

### DIFF
--- a/.stories/Datepicker.stories.tsx
+++ b/.stories/Datepicker.stories.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import './components/datepicker.css';
 import Datepicker from './components/Datepicker';
 import { isDateValid } from '../src/util';
+import { SelectedDates } from '../src/types';
 
 export default {
   title: 'RHDP Examples',
@@ -124,19 +125,19 @@ export const ShowHide = () => {
     <div>
       <button
         autoFocus={true}
+        className="btn btn-primary"
         onClick={() => {
           setDatepickerVisible(!isDatepickerVisible);
         }}
-        style={{ marginBottom: '8px' }}
         type="button"
       >
         {isDatepickerVisible ? 'Hide' : 'Show'} datepicker
       </button>
-      <p style={{ marginBottom: '28px' }}>Currently selected date: {selectedDate}</p>
 
       {isDatepickerVisible && (
         <Datepicker
           focusOnInit={true}
+          hasFocusTrap={true}
           onClose={() => setDatepickerVisible(false)}
           labels={labels}
           mode="single"
@@ -147,49 +148,104 @@ export const ShowHide = () => {
           selectDates={selectedDate}
         />
       )}
+
+      <p className="mt-4">Currently selected date: {selectedDate}</p>
     </div>
   );
 };
 
+const convertUSDateToISO = (date) => {
+  const [month, day, year] = date?.split('/');
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return null;
+};
+
 export const EditableInput = () => {
-  const [selectedDate, setSelectedDate] = useState('2021-11-08');
-  const [typedDate, setTypedDate] = useState('2021-11-08');
-  const [isTypedDateValid, setIsTypedDateValid] = useState(true);
+  const [selectedDate, setSelectedDate] = useState<SelectedDates>();
+  const [displayDate, setDisplayDate] = useState<string>('');
+  const [isDatepickerOpen, setIsDatepickerOpen] = useState(false);
+  const [invalid, setInvalid] = useState(true);
+
+  useEffect(() => {
+    const isoDate = convertUSDateToISO(displayDate);
+    const target = document.getElementById('datepicker-input');
+    const isValid = isDateValid(isoDate);
+    setInvalid(!isValid);
+    if (isValid) {
+      setSelectedDate(isoDate);
+      (target as HTMLInputElement)?.setCustomValidity('');
+    } else {
+      (target as HTMLInputElement)?.setCustomValidity('error');
+    }
+    (target as HTMLInputElement)?.checkValidity();
+  }, [displayDate]);
+
+  useEffect(() => {
+    setDisplayDate('02/02/2022');
+  }, []);
+
   return (
-    <div>
-      <label htmlFor="date-input" style={{ display: 'block', fontWeight: 'bold' }}>
-        Enter a valid date in YYYY-MM-DD format
-      </label>
-      <input
-        autoComplete="false"
-        className="date-input"
-        id="date-input"
-        onChange={(evt) => {
-          setTypedDate(evt.target.value);
-          if (isDateValid(evt.target.value)) {
-            console.log('Setting selected date to ', evt.target.value);
-            setSelectedDate(evt.target.value);
-            setIsTypedDateValid(true);
-          } else {
-            setIsTypedDateValid(false);
-          }
-        }}
-        pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}"
-        type="text"
-        value={typedDate}
-      />
-      {!isTypedDateValid && <div>The typed date is not valid</div>}
-      <div style={{ marginTop: '20px' }}>
-        <Datepicker
-          labels={labels}
-          mode="single"
-          onChange={(newDate) => {
-            console.log('Got a new date', newDate);
-            setSelectedDate(newDate as string);
-            setTypedDate(newDate as string);
-          }}
-          selectDates={selectedDate}
-        />
+    <div className="App m-4">
+      <div className="form-group position-relative" style={{ maxWidth: '220px' }}>
+        <label htmlFor="datepicker-input">Select a date (mm/dd/yyyy format)</label>
+        <div className="input-group was-validated">
+          <input
+            aria-describedby="invalid-date-format"
+            aria-invalid={invalid}
+            className="form-control"
+            id="datepicker-input"
+            onChange={(evt) => {
+              setDisplayDate(evt.target.value);
+            }}
+            placeholder="mm/dd/yyyy"
+            type="text"
+            value={displayDate}
+          />
+          <div className="input-group-append">
+            <button
+              aria-describedby={`${invalid ? 'datepicker-input' : ''}`}
+              aria-haspopup={true}
+              aria-label="Open datepicker"
+              className="btn btn-primary input-group-text"
+              data-testid="btn-open-datepicker"
+              onClick={() => setIsDatepickerOpen(!isDatepickerOpen)}
+              type="button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                className="bi bi-calendar3"
+                viewBox="0 0 16 16"
+              >
+                <path d="M14 0H2a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM1 3.857C1 3.384 1.448 3 2 3h12c.552 0 1 .384 1 .857v10.286c0 .473-.448.857-1 .857H2c-.552 0-1-.384-1-.857V3.857z" />
+                <path d="M6.5 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm-9 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm-9 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        {invalid && (
+          <div id="invalid-date-format" role="alert">
+            Date should be in mm/dd/yyyy format
+          </div>
+        )}
+
+        {isDatepickerOpen && (
+          <Datepicker
+            focusOnInit={true}
+            hasFocusTrap={true}
+            onChange={(newDate) => {
+              const [year, month, day] = (newDate as string).match(/\d+/g) || ['', '', ''];
+              setDisplayDate(`${month}/${day}/${year}`);
+              setSelectedDate(newDate);
+            }}
+            onClose={() => setIsDatepickerOpen(false)}
+            selectDates={selectedDate as SelectedDates}
+          />
+        )}
       </div>
     </div>
   );

--- a/.stories/components/Datepicker.tsx
+++ b/.stories/components/Datepicker.tsx
@@ -10,13 +10,14 @@ const Datepicker = ({
   blockedDates,
   datepickerMethods,
   focusOnInit,
-  onClose,
+  hasFocusTrap,
   labels,
   locale,
   maxDate,
   minDate,
   mode,
   onChange,
+  onClose,
   selectDates,
   weekStart,
 }: DatepickerProps) => {
@@ -25,19 +26,22 @@ const Datepicker = ({
     displayDaysOfTheWeek,
     displayMonth,
     displayYear,
+    focusedDate,
     getCalendarContainerProps,
     getCalendarWeekContainerProps,
     getDayOfTheWeekProps,
     getDaysOfTheWeekContainerProps,
-    getOnCloseButtonProps,
     getControlsContainerProps,
     getDatepickerContainerProps,
     getDayButtonProps,
     getMonthYearContainerProps,
     getNextMonthButtonProps,
+    getOnCloseButtonProps,
     getPreviousMonthButtonProps,
     getNextYearButtonProps,
     getPreviousYearButtonProps,
+    hoveredDate,
+    id,
     selectedDates,
     setMonth,
     setYear,
@@ -45,12 +49,13 @@ const Datepicker = ({
   } = useDatepicker({
     blockedDates,
     focusOnInit,
-    onClose,
+    hasFocusTrap,
     labels,
     locale,
     maxDate,
     minDate,
     mode,
+    onClose,
     selectDates,
     onChange,
     weekStart,
@@ -180,7 +185,11 @@ const Datepicker = ({
   };
 
   return (
-    <div className="datepicker-container" data-testid="div-datepicker" {...getDatepickerContainerProps()}>
+    <div
+      className={`datepicker-container ${onClose ? 'datepicker-popover' : ''}`}
+      data-testid="div-datepicker"
+      {...getDatepickerContainerProps()}
+    >
       {onClose && (
         <div className="close-container">
           <button

--- a/.stories/components/datepicker.css
+++ b/.stories/components/datepicker.css
@@ -74,6 +74,14 @@ body {
   margin: 20px;
   padding: 16px;
   position: relative;
+  background-color: #fff;
+}
+
+.datepicker-popover {
+  position: absolute;
+  margin: 0;
+  margin-top: 20px;
+  z-index: 1;
 }
 
 .month-year-title-container {
@@ -84,6 +92,7 @@ body {
 .month-year-title {
   font-size: 1.75rem;
   font-weight: bold;
+  line-height: 1.1;
 }
 
 .day-container {
@@ -96,6 +105,7 @@ body {
   position: relative;
   margin: 1px 0;
   outline: 0;
+  z-index: 1;
 }
 .day-container:before,
 .day-container:after {
@@ -106,7 +116,6 @@ body {
   left: 0;
   right: 0;
   z-index: -1;
-  box-shadow: inset 0 0 0 1px #fff;
 }
 .day-container:hover {
   box-shadow: inset 0 0 4px #000;

--- a/.stories/tests/Testing.stories.tsx
+++ b/.stories/tests/Testing.stories.tsx
@@ -1,5 +1,6 @@
-import { ReactNode, useRef, useState } from 'react';
+import { ReactNode, useEffect, useRef, useState } from 'react';
 import { DateSelectionMode, SelectedDates, WeekStart } from '../../src/types';
+import { isDateValid } from '../../src/util';
 import Datepicker from '../components/Datepicker';
 
 export default {
@@ -30,6 +31,7 @@ const BaseTestingComponent = ({
     <div>
       <button
         autoFocus={true}
+        className="btn btn-primary mr-1 my-1"
         data-testid="btn-focus-start"
         onClick={console.clear}
         style={{ marginBottom: '20px' }}
@@ -38,7 +40,12 @@ const BaseTestingComponent = ({
         Focus Point
       </button>
       {datepicker}
-      <button data-testid="btn-focus-end" style={{ marginTop: '20px' }} type="button">
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-focus-end"
+        style={{ marginTop: '20px' }}
+        type="button"
+      >
         Focus Point
       </button>
       <div style={{ marginTop: '20px' }}>
@@ -139,7 +146,11 @@ export const BlockedDates = () => {
 
   const additionalControls = (
     <>
-      <button data-testid="btn-set-blocked-dates" onClick={() => setBlockedDates(['2021-11-10'])}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-blocked-dates"
+        onClick={() => setBlockedDates(['2021-11-10'])}
+      >
         Set blockedDates to ['2021-11-10']
       </button>
     </>
@@ -196,7 +207,11 @@ export const LocalePreselected = () => {
 
   const additionalControls = (
     <>
-      <button data-testid="btn-set-locale-fr-fr" onClick={() => setLocale('fr-FR')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-locale-fr-fr"
+        onClick={() => setLocale('fr-FR')}
+      >
         Switch to French
       </button>
     </>
@@ -228,10 +243,18 @@ export const MaxDate = () => {
 
   const additionalControls = (
     <>
-      <button data-testid="btn-set-max-date-2022-01-08" onClick={() => setMaxDate('2022-01-08')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-max-date-2022-01-08"
+        onClick={() => setMaxDate('2022-01-08')}
+      >
         Set maxDate to 2022-01-08
       </button>
-      <button data-testid="btn-set-max-date-2024-01-08" onClick={() => setMaxDate('2024-01-08')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-max-date-2024-01-08"
+        onClick={() => setMaxDate('2024-01-08')}
+      >
         Set maxDate to 2024-01-08
       </button>
     </>
@@ -265,10 +288,18 @@ export const MinDate = () => {
 
   const additionalControls = (
     <>
-      <button data-testid="btn-set-min-date-2021-08-08" onClick={() => setMinDate('2021-08-08')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-min-date-2021-08-08"
+        onClick={() => setMinDate('2021-08-08')}
+      >
         Set minDate to 2021-08-08
       </button>
-      <button data-testid="btn-set-min-date-2019-08-08" onClick={() => setMinDate('2019-08-08')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-min-date-2019-08-08"
+        onClick={() => setMinDate('2019-08-08')}
+      >
         Set minDate to 2019-08-08
       </button>
     </>
@@ -349,29 +380,46 @@ export const NoDateSelected = () => {
 
   const additionalControls = (
     <>
-      <button data-testid="btn-set-mode-single" onClick={() => setMode('single')}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-mode-single" onClick={() => setMode('single')}>
         Set mode to single
       </button>
-      <button data-testid="btn-set-mode-range" onClick={() => setMode('range')}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-mode-range" onClick={() => setMode('range')}>
         Set mode to range
       </button>
-      <button data-testid="btn-set-mode-multiple" onClick={() => setMode('multiple')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-mode-multiple"
+        onClick={() => setMode('multiple')}
+      >
         Set mode to multiple
       </button>
-      <button data-testid="btn-set-mode-max-3" onClick={() => setMode(3)}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-mode-max-3" onClick={() => setMode(3)}>
         Set mode to multiple, max of 3
       </button>
       <br />
-      <button data-testid="btn-set-select-dates-null" onClick={() => setSelectDates(null)}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-select-dates-null"
+        onClick={() => setSelectDates(null)}
+      >
         Set selectDates to null
       </button>
-      <button data-testid="btn-set-select-dates-string" onClick={() => setSelectDates('2021-11-29')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-select-dates-string"
+        onClick={() => setSelectDates('2021-11-29')}
+      >
         Set selectDates to '2021-11-29'
       </button>
-      <button data-testid="btn-set-select-dates-range" onClick={() => setSelectDates(['2021-11-20', '2021-11-26'])}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-select-dates-range"
+        onClick={() => setSelectDates(['2021-11-20', '2021-11-26'])}
+      >
         Set selectDates to ['2021-11-20', '2021-11-26']
       </button>
       <button
+        className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-select-dates-multiple"
         onClick={() => setSelectDates(['2021-11-10', '2021-11-20', '2021-11-30'])}
       >
@@ -429,35 +477,53 @@ export const SingleDatePreselected = () => {
   const datepickerMethods = useRef<{ setMonth(month: number): void; setYear(year: number): void }>();
   const additionalControls = (
     <>
-      <button data-testid="btn-set-mode-single" onClick={() => setMode('single')}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-mode-single" onClick={() => setMode('single')}>
         Set mode to single
       </button>
-      <button data-testid="btn-set-mode-range" onClick={() => setMode('range')}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-mode-range" onClick={() => setMode('range')}>
         Set mode to range
       </button>
-      <button data-testid="btn-set-mode-multiple" onClick={() => setMode('multiple')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-mode-multiple"
+        onClick={() => setMode('multiple')}
+      >
         Set mode to multiple
       </button>
-      <button data-testid="btn-set-mode-max-3" onClick={() => setMode(3)}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-mode-max-3" onClick={() => setMode(3)}>
         Set mode to multiple, max of 3
       </button>
       <br />
-      <button data-testid="btn-set-select-dates-null" onClick={() => setSelectDates(null)}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-select-dates-null"
+        onClick={() => setSelectDates(null)}
+      >
         Set selectDates to null
       </button>
-      <button data-testid="btn-set-select-dates-string" onClick={() => setSelectDates('2021-11-29')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-select-dates-string"
+        onClick={() => setSelectDates('2021-11-29')}
+      >
         Set selectDates to '2021-11-29'
       </button>
-      <button data-testid="btn-set-select-dates-range" onClick={() => setSelectDates(['2021-11-20', '2021-11-26'])}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-select-dates-range"
+        onClick={() => setSelectDates(['2021-11-20', '2021-11-26'])}
+      >
         Set selectDates to ['2021-11-20', '2021-11-26']
       </button>
       <button
+        className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-select-dates-multiple"
         onClick={() => setSelectDates(['2021-11-10', '2021-11-20', '2021-11-30'])}
       >
         Set selectDates to ['2021-11-10', '2021-11-20', '2021-11-30']
       </button>
       <button
+        className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-select-dates-many-multiple"
         onClick={() =>
           setSelectDates([
@@ -477,19 +543,32 @@ export const SingleDatePreselected = () => {
         Set selectDates to ['2021-11-10', '2021-11-11', '2021-11-12', '2021-11-13', '2021-11-14', '2021-11-15',
         '2021-11-16', '2021-11-17', '2021-11-18', '2021-11-19']
       </button>
-      <button data-testid="btn-set-select-dates-invalid" onClick={() => setSelectDates('2o2l-ll-lo')}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-select-dates-invalid"
+        onClick={() => setSelectDates('2o2l-ll-lo')}
+      >
         Set selectDates to 2o2l-ll-lo
       </button>
       <button
+        className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-select-dates-multiple-with-invalid"
         onClick={() => setSelectDates(['2o2l-ll-lo', '2021-11-10', '2021-11-11', '2021-11-12'])}
       >
         Set selectDates to ['2o2l-ll-lo','2021-11-10', '2021-11-11', '2021-11-12']
       </button>
-      <button data-testid="btn-set-month-february" onClick={() => datepickerMethods.current.setMonth(2)}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-month-february"
+        onClick={() => datepickerMethods.current.setMonth(2)}
+      >
         Set Month to February
       </button>
-      <button data-testid="btn-set-year-2024" onClick={() => datepickerMethods.current.setYear(2024)}>
+      <button
+        className="btn btn-primary mr-1 my-1"
+        data-testid="btn-set-year-2024"
+        onClick={() => datepickerMethods.current.setYear(2024)}
+      >
         Set Year to 2024
       </button>
     </>
@@ -545,10 +624,10 @@ export const WeekStartPreselected = () => {
 
   const additionalControls = (
     <>
-      <button data-testid="btn-set-week-start-0" onClick={() => setWeekStart(0)}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-week-start-0" onClick={() => setWeekStart(0)}>
         Switch to Sunday
       </button>
-      <button data-testid="btn-set-week-start-1" onClick={() => setWeekStart(1)}>
+      <button className="btn btn-primary mr-1 my-1" data-testid="btn-set-week-start-1" onClick={() => setWeekStart(1)}>
         Switch to Monday
       </button>
     </>
@@ -584,14 +663,14 @@ export const ShowHide = () => {
 
   return (
     <div>
-      <div>
+      <div style={{ marginBottom: '20px' }}>
         <button
           autoFocus={true}
+          className="btn btn-primary mr-1 my-1"
           data-testid="btn-show-hide-single"
           onClick={() => {
             setSingleDatepickerVisible(!isSingleDatepickerVisible);
           }}
-          style={{ marginBottom: '20px' }}
           type="button"
         >
           {isSingleDatepickerVisible ? 'Hide' : 'Show'} single datepicker
@@ -600,23 +679,23 @@ export const ShowHide = () => {
         {isSingleDatepickerVisible && (
           <Datepicker
             focusOnInit={true}
+            hasFocusTrap={true}
             onClose={() => setSingleDatepickerVisible(false)}
             labels={labels}
             mode="single"
             onChange={(newDate) => {
               console.log('Got a new date', newDate);
             }}
-            selectDates="2021-11-08"
           />
         )}
       </div>
-      <div>
+      <div style={{ marginBottom: '20px' }}>
         <button
+          className="btn btn-primary mr-1 my-1"
           data-testid="btn-show-hide-range"
           onClick={() => {
             setRangeDatepickerVisible(!isRangeDatepickerVisible);
           }}
-          style={{ marginBottom: '20px' }}
           type="button"
         >
           {isRangeDatepickerVisible ? 'Hide' : 'Show'} range datepicker
@@ -625,6 +704,7 @@ export const ShowHide = () => {
         {isRangeDatepickerVisible && (
           <Datepicker
             focusOnInit={true}
+            hasFocusTrap={true}
             onClose={() => setRangeDatepickerVisible(false)}
             labels={labels}
             mode="range"
@@ -634,13 +714,13 @@ export const ShowHide = () => {
           />
         )}
       </div>
-      <div>
+      <div style={{ marginBottom: '20px' }}>
         <button
+          className="btn btn-primary mr-1 my-1"
           data-testid="btn-show-hide-multiple"
           onClick={() => {
             setMultipleDatepickerVisible(!isMultipleDatepickerVisible);
           }}
-          style={{ marginBottom: '20px' }}
           type="button"
         >
           {isMultipleDatepickerVisible ? 'Hide' : 'Show'} multiple datepicker
@@ -649,6 +729,7 @@ export const ShowHide = () => {
         {isMultipleDatepickerVisible && (
           <Datepicker
             focusOnInit={true}
+            hasFocusTrap={true}
             onClose={() => setMultipleDatepickerVisible(false)}
             labels={labels}
             mode="multiple"
@@ -658,13 +739,13 @@ export const ShowHide = () => {
           />
         )}
       </div>
-      <div>
+      <div style={{ marginBottom: '20px' }}>
         <button
+          className="btn btn-primary mr-1 my-1"
           data-testid="btn-show-hide-multiple-max"
           onClick={() => {
             setMultipleMaxDatepickerVisible(!isMultipleMaxDatepickerVisible);
           }}
-          style={{ marginBottom: '20px' }}
           type="button"
         >
           {isMultipleMaxDatepickerVisible ? 'Hide' : 'Show'} multiple max datepicker
@@ -673,6 +754,7 @@ export const ShowHide = () => {
         {isMultipleMaxDatepickerVisible && (
           <Datepicker
             focusOnInit={true}
+            hasFocusTrap={true}
             onClose={() => setMultipleMaxDatepickerVisible(false)}
             labels={labels}
             mode={4}
@@ -686,54 +768,99 @@ export const ShowHide = () => {
   );
 };
 
+const convertUSDateToISO = (date) => {
+  const [month, day, year] = date?.split('/');
+  if (year && month && day) {
+    return `${year}-${month}-${day}`;
+  }
+  return null;
+};
+
 export const Input = () => {
-  const [selectedDate, setSelectedDate] = useState<SelectedDates>('2021-11-08');
-  const [displayDate, setDisplayDate] = useState<string>();
+  const [selectedDate, setSelectedDate] = useState<SelectedDates>();
+  const [displayDate, setDisplayDate] = useState<string>('');
   const [isDatepickerOpen, setIsDatepickerOpen] = useState(false);
+  const [invalid, setInvalid] = useState(true);
+
+  useEffect(() => {
+    const isoDate = convertUSDateToISO(displayDate);
+    const target = document.getElementById('datepicker-input');
+    const isValid = isDateValid(isoDate);
+    setInvalid(!isValid);
+    if (isValid) {
+      setSelectedDate(isoDate);
+      (target as HTMLInputElement)?.setCustomValidity('');
+    } else {
+      (target as HTMLInputElement)?.setCustomValidity('error');
+    }
+    (target as HTMLInputElement)?.checkValidity();
+  }, [displayDate]);
+
+  useEffect(() => {
+    setDisplayDate('02/02/2022');
+  }, []);
 
   return (
-    <div>
-      <label htmlFor="datepicker-input">Select a date</label>
-      <br />
-      <input
-        defaultValue={displayDate}
-        id="datepicker-input"
-        onChange={(evt) => {
-          const [month, day, year] = evt.target.value.match(/\d+/g) || ['', '', ''];
-          setDisplayDate(evt.target.value);
-          setSelectedDate(`${year}-${month}-${day}`);
-        }}
-        placeholder="mm/dd/yyyy"
-        type="text"
-      />
+    <div className="App m-4">
+      <div className="form-group position-relative" style={{ maxWidth: '220px' }}>
+        <label htmlFor="datepicker-input">Select a date (mm/dd/yyyy format)</label>
+        <div className="input-group was-validated">
+          <input
+            aria-describedby="invalid-date-format"
+            aria-invalid={invalid}
+            className="form-control"
+            id="datepicker-input"
+            onChange={(evt) => {
+              setDisplayDate(evt.target.value);
+            }}
+            placeholder="mm/dd/yyyy"
+            type="text"
+            value={displayDate}
+          />
+          <div className="input-group-append">
+            <button
+              aria-describedby={`${invalid ? 'datepicker-input' : ''}`}
+              aria-haspopup={true}
+              aria-label="Open datepicker"
+              className="btn btn-primary input-group-text"
+              data-testid="btn-open-datepicker"
+              onClick={() => setIsDatepickerOpen(!isDatepickerOpen)}
+              type="button"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                fill="currentColor"
+                className="bi bi-calendar3"
+                viewBox="0 0 16 16"
+              >
+                <path d="M14 0H2a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zM1 3.857C1 3.384 1.448 3 2 3h12c.552 0 1 .384 1 .857v10.286c0 .473-.448.857-1 .857H2c-.552 0-1-.384-1-.857V3.857z" />
+                <path d="M6.5 7a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm-9 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm-9 3a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2zm3 0a1 1 0 1 0 0-2 1 1 0 0 0 0 2z" />
+              </svg>
+            </button>
+          </div>
+        </div>
+        {invalid && (
+          <div id="invalid-date-format" role="alert">
+            Date should be in mm/dd/yyyy format
+          </div>
+        )}
 
-      <button data-testid="btn-datepicker-icon" onClick={() => setIsDatepickerOpen(!isDatepickerOpen)} type="button">
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          width="16"
-          height="16"
-          fill="currentColor"
-          className="bi bi-calendar"
-          viewBox="0 0 16 16"
-        >
-          <path d="M3.5 0a.5.5 0 0 1 .5.5V1h8V.5a.5.5 0 0 1 1 0V1h1a2 2 0 0 1 2 2v11a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2h1V.5a.5.5 0 0 1 .5-.5zM1 4v10a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V4H1z" />
-        </svg>
-      </button>
-
-      {isDatepickerOpen && (
-        <Datepicker
-          focusOnInit={true}
-          onChange={(newDate) => {
-            const [year, month, day] = (newDate as string).match(/\d+/g) || ['', '', ''];
-            if (year && month && day) {
+        {isDatepickerOpen && (
+          <Datepicker
+            focusOnInit={true}
+            hasFocusTrap={true}
+            onChange={(newDate) => {
+              const [year, month, day] = (newDate as string).match(/\d+/g) || ['', '', ''];
               setDisplayDate(`${month}/${day}/${year}`);
-            }
-            setSelectedDate(newDate);
-          }}
-          onClose={() => setIsDatepickerOpen(false)}
-          selectDates={selectedDate as SelectedDates}
-        />
-      )}
+              setSelectedDate(newDate);
+            }}
+            onClose={() => setIsDatepickerOpen(false)}
+            selectDates={selectedDate as SelectedDates}
+          />
+        )}
+      </div>
     </div>
   );
 };

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,1 @@
+<link href="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/css/bootstrap.min.css" type="text/css" rel="stylesheet">

--- a/README.md
+++ b/README.md
@@ -28,26 +28,27 @@ Zero dependencies & purpose built.
 
 All props are fully typed in Typescript. This small subset is provided here for quick reference. [View the full types](https://github.com/roypearce/rhdp/tree/main/dist/declarations).
 
-| Property                     | Type                                          | Description                                                                                    |
-| ---------------------------- | --------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `blockedDates`               | `string[] \| string`                          | YYYY-MM-DD format, prevents selection of specified dates                                       |
-| `focusOnInit`                | `boolean`                                     | Will cause focus to be set to the first of an array of dates or today                          |
-| `labels`                     | `object`                                      | Button labels for accessibility, English defaults provided                                     |
-| `labels.closeButton`         | `string`                                      |                                                                                                |
-| `labels.dateSelected`        | `string`                                      |                                                                                                |
-| `labels.nextMonthButton`     | `string`                                      |                                                                                                |
-| `labels.nextYearButton`      | `string`                                      |                                                                                                |
-| `labels.previousMonthButton` | `string`                                      |                                                                                                |
-| `labels.previousYearButton`  | `string`                                      |                                                                                                |
-| `labels.today`               | `string`                                      |                                                                                                |
-| `locale`                     | `Intl.DateTimeFormat`                         | Defaults to en-US, see Localization section for more details                                   |
-| `maxDate`                    | `string`                                      | YYYY-MM-DD format, if set prevents selection & navigation past that date                       |
-| `minDate`                    | `string`                                      | YYYY-MM-DD format, if set prevents selection & navigation before that date                     |
-| `mode`                       | `'single' \| 'range' \| 'multiple' \| number` | Sets the selection mode for the datepicker, number is a max # of dates                         |
-| `onChange`                   | `function(string[] \| string)`                | Function called whenever the selected dates change (string in single mode, otherwise an array) |
-| `onClose`                    | `function()`                                  | Function which is executed when date selection criteria is satisfied                           |
-| `selectDates`                | `string[] \| string`                          | YYYY-MM-DD format, pre-selects the supplied dates                                              |
-| `weekStart`                  | `0 \| 1`                                      | Changes the start day of the week from Sunday to Monday                                        |
+| Property                     | Type                                          | Description                                                                                                 |
+| ---------------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `blockedDates`               | `string[] \| string`                          | YYYY-MM-DD format, prevents selection of specified dates                                                    |
+| `focusOnInit`                | `boolean`                                     | Will cause focus to be set to the first of an array of dates or today                                       |
+| `hasFocusTrap`               | `boolean`                                     | Will cause focus to be constrained to the datepicker and controls while the datepicker is open as a popover |
+| `labels`                     | `object`                                      | Button labels for accessibility, English defaults provided                                                  |
+| `labels.closeButton`         | `string`                                      |                                                                                                             |
+| `labels.dateSelected`        | `string`                                      |                                                                                                             |
+| `labels.nextMonthButton`     | `string`                                      |                                                                                                             |
+| `labels.nextYearButton`      | `string`                                      |                                                                                                             |
+| `labels.previousMonthButton` | `string`                                      |                                                                                                             |
+| `labels.previousYearButton`  | `string`                                      |                                                                                                             |
+| `labels.today`               | `string`                                      |                                                                                                             |
+| `locale`                     | `Intl.DateTimeFormat`                         | Defaults to en-US, see Localization section for more details                                                |
+| `maxDate`                    | `string`                                      | YYYY-MM-DD format, if set prevents selection & navigation past that date                                    |
+| `minDate`                    | `string`                                      | YYYY-MM-DD format, if set prevents selection & navigation before that date                                  |
+| `mode`                       | `'single' \| 'range' \| 'multiple' \| number` | Sets the selection mode for the datepicker, number is a max # of dates                                      |
+| `onChange`                   | `function(string[] \| string)`                | Function called whenever the selected dates change (string in single mode, otherwise an array)              |
+| `onClose`                    | `function()`                                  | Function which is executed when date selection criteria is satisfied                                        |
+| `selectDates`                | `string[] \| string`                          | YYYY-MM-DD format, pre-selects the supplied dates                                                           |
+| `weekStart`                  | `0 \| 1`                                      | Changes the start day of the week from Sunday to Monday                                                     |
 
 ## Returned props
 
@@ -59,6 +60,7 @@ All returned props are fully typed in Typescript. This small subset is provided 
 | `displayDaysOfTheWeek`           | `DisplayDaysOfTheWeek[]` | Each day of the week, localized, available in full, short and narrow formats                 |
 | `displayMonth`                   | `string`                 | Full month name, localized, of the displayed calendar month                                  |
 | `displayYear`                    | `string`                 | 4 digit year of the displayed calendar month                                                 |
+| `focusedDate`                    | `string`                 | The date which currently has focus                                                           |
 | `getCalendarContainerProps`      | `function()`             | Getter to apply attributes, methods & props to the calendar container                        |
 | `getCalendarWeekContainerProps`  | `function()`             | Getter to apply attributes, methods & props to the calendar week container                   |
 | `getDayOfTheWeekProps`           | `function()`             | Getter to apply attributes, methods & props to the each day of the week                      |
@@ -72,6 +74,8 @@ All returned props are fully typed in Typescript. This small subset is provided 
 | `getOnCloseButtonProps`          | `function()`             | Getter to apply attributes, methods & props to the hide datepicker button                    |
 | `getPreviousMonthButtonProps`    | `function()`             | Getter to apply attributes, methods & props to the previous month button                     |
 | `getPreviousYearButtonProps`     | `function()`             | Getter to apply attributes, methods & props to the previous year button                      |
+| `hoveredDate`                    | `string`                 | The date which is currently hovered                                                          |
+| `id`                             | `string`                 | The id of the datepicker ]                                                                   |
 | `setMonth`                       | `function(number)`       | Set the month of the year for the calendar in the datepicker, 1 based (1-12)                 |
 | `setYear`                        | `function(number)`       | Set the 4 digit year for the calendar in the datepicker                                      |
 | `today`                          | `string`                 | Today's date in YYYY-MM-DD format                                                            |
@@ -92,6 +96,10 @@ All returned props are fully typed in Typescript. This small subset is provided 
 | `rangeStart`  | `boolean` | Whether the day is the start of the selected range (mode: 'range') |
 | `selected`    | `boolean` | Whether the day is selected                                        |
 | `today`       | `boolean` | Whether the day is today                                           |
+
+## Popover
+
+If the datepicker is going to be contained in a popover, `focusOnInit`, `hasFocusTrap` and `onClose` should be set in `useDatepicker` for proper operation. The button which shows/hides the datepicker should have `aria-haspopup={true}`. If an icon is used in the button instead of descriptive text, it should also have the `aria-label` attribute with an appropriate label. `aria-describedby` should contain the id of the element which contains the updated selected date if the value of the date needs to be announced when focus is on the open datepicker button.
 
 ## Localization
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhdp",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "RHDP - React Hook Datepicker. A React Hook based primitive to build simple, flexible datepicker components that are WAI-ARIA compliant, and support localization.",
   "author": "Roy Pearce <rhdp@roypearce.us> (github.com/roypearce)",
   "repository": "git@github.com:roypearce/rhdp.git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from './chain-date';
 export * from './types';
 export * from './use-datepicker';
+export { isDateValid } from './util';

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export type SelectedDates = string | string[];
 export interface UseDatepickerProps {
   blockedDates?: SelectedDates;
   focusOnInit?: boolean;
-  onClose?(): void;
+  hasFocusTrap?: boolean;
   labels?: {
     closeButton?: string;
     dateSelected?: string;
@@ -91,6 +91,7 @@ export interface UseDatepickerProps {
   minDate?: string;
   mode?: DateSelectionMode;
   onChange?(newDates: SelectedDates): void;
+  onClose?(): void;
   selectDates?: SelectedDates;
   weekStart?: WeekStart;
 }
@@ -101,7 +102,6 @@ export interface UseDatepicker {
   displayMonth: string;
   displayYear: number;
   focusedDate: string;
-  hoveredDate: string;
   getCalendarContainerProps(): {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onBlur(evt: any): void;
@@ -110,18 +110,6 @@ export interface UseDatepicker {
   getCalendarWeekContainerProps(): {
     [key: string]: string;
   };
-  getDayOfTheWeekProps(index: number): {
-    abbr: string;
-    id: string;
-    scope: string;
-  };
-  getDaysOfTheWeekContainerProps(): {
-    role: string;
-  };
-  getOnCloseButtonProps(): {
-    'aria-label': string;
-    onClick(): void;
-  };
   getControlsContainerProps(): {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onBlur(evt: any): void;
@@ -129,6 +117,7 @@ export interface UseDatepicker {
   };
   getDatepickerContainerProps(): {
     'aria-activedescendant': string;
+    id: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onBlur(evt: any): void;
     onFocus(): void;
@@ -139,6 +128,14 @@ export interface UseDatepicker {
     id: string;
     onClick(): void;
     tabIndex: number;
+  };
+  getDayOfTheWeekProps(index: number): {
+    abbr: string;
+    id: string;
+    scope: string;
+  };
+  getDaysOfTheWeekContainerProps(): {
+    role: string;
   };
   getMonthYearContainerProps(): {
     [key: string]: string;
@@ -155,10 +152,16 @@ export interface UseDatepicker {
     onClick(): void;
     tabIndex: number;
   };
+  getOnCloseButtonProps(): {
+    'aria-label': string;
+    onClick(): void;
+  };
   getPreviousYearButtonProps(): {
     onClick(): void;
     tabIndex: number;
   };
+  hoveredDate: string;
+  id: string;
   selectedDates: SelectedDates;
   setMonth(month: number): void;
   setYear(year: number): void;

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,8 +54,16 @@ export const getNewDisplayTimePeriods = (newTimePeriod: string) => {
   };
 };
 
+export const getFocusableElements = (currentQuerySelector: HTMLElement | null) => {
+  return [
+    ...(currentQuerySelector?.querySelectorAll(
+      'a:not([disabled]):not([tabindex="-1"]), button:not([disabled]):not([tabindex="-1"]), input:not([disabled]):not([tabindex="-1"]), [tabindex]:not([disabled]):not([tabindex="-1"])',
+    ) || []),
+  ];
+};
+
 let uniqueId = 0;
-export function getUniqueId(prefix = 'rdhp-id-') {
+export function getUniqueId(prefix = 'rhdp-id-') {
   return `${prefix}${(uniqueId += 1)}`;
 }
 

--- a/tests/cypress/integration/controls.spec.ts
+++ b/tests/cypress/integration/controls.spec.ts
@@ -8,9 +8,9 @@ describe('Close button control', () => {
 
   it('should close the datepicker when Enter is pressed', () => {
     cy.visitStory('tests--input');
-    cy.getId('btn-datepicker-icon').click();
+    cy.getId('btn-open-datepicker').click();
     cy.getId('btn-close').should('be.visible');
-    cy.getId('btn-day-2021-11-08').should('have.attr', 'aria-selected', 'true');
+    cy.getId('btn-day-2022-02-02').should('have.attr', 'aria-selected', 'true');
     cy.realPress(['Shift', 'Tab']);
     cy.realPress(['Shift', 'Tab']);
     cy.realPress(['Shift', 'Tab']);
@@ -22,9 +22,9 @@ describe('Close button control', () => {
   });
 
   it('should not change the value when closed with the Enter key', () => {
-    cy.getId('btn-datepicker-icon').click();
+    cy.getId('btn-open-datepicker').click();
     cy.getId('btn-close').should('be.visible');
-    cy.getId('btn-day-2021-11-08').should('have.attr', 'aria-selected', 'true');
+    cy.getId('btn-day-2022-02-02').should('have.attr', 'aria-selected', 'true');
   });
 });
 

--- a/tests/cypress/integration/keys.spec.ts
+++ b/tests/cypress/integration/keys.spec.ts
@@ -1,3 +1,7 @@
+import ChainDate from '../../../src/chain-date';
+
+const today = new ChainDate().format();
+
 describe('Key based navigation', () => {
   describe('Home navigation', () => {
     it('should go to the start of the month when Home is pressed', () => {
@@ -130,7 +134,7 @@ describe('Key based navigation', () => {
       cy.getId('div-datepicker').should('not.exist');
       cy.getId('btn-show-hide-single').click();
       cy.getId('div-datepicker').should('exist').should('be.visible');
-      cy.getId('btn-day-2021-11-08').should('have.focus');
+      cy.getId(`btn-day-${today}`).should('have.focus');
       cy.realPress('Escape');
       cy.getId('div-datepicker').should('not.exist');
     });

--- a/tests/cypress/integration/show-hide.spec.ts
+++ b/tests/cypress/integration/show-hide.spec.ts
@@ -1,6 +1,7 @@
-import ChainDate, { TimePeriod } from '../../../src/chain-date';
+import ChainDate from '../../../src/chain-date';
 
 const firstDayOfMonth = new ChainDate().startOfMonth().format();
+const today = new ChainDate().format();
 
 describe('Show/hide functionality', () => {
   it('should focus on init if that prop is set', () => {
@@ -9,7 +10,7 @@ describe('Show/hide functionality', () => {
     cy.getId('div-datepicker').should('not.exist');
     cy.getId('btn-show-hide-single').click();
     cy.getId('div-datepicker').should('exist').should('be.visible');
-    cy.getId('btn-day-2021-11-08').should('have.focus');
+    cy.getId(`btn-day-${today}`).should('have.focus');
   });
 
   it('should focus on the element that had focus before it was shown', () => {

--- a/tests/cypress/integration/tabbing.spec.ts
+++ b/tests/cypress/integration/tabbing.spec.ts
@@ -1,6 +1,38 @@
 import ChainDate from '../../../src/chain-date';
 
 describe('Tabbing', () => {
+  it('should create a focus trap if hasFocusTrap is set', () => {
+    cy.visitStory('tests--input');
+    cy.getId('div-datepicker').should('not.exist');
+    cy.getId('btn-open-datepicker').click();
+    cy.getId('div-datepicker').should('be.visible');
+    cy.getId('btn-day-2022-02-02').should('have.focus');
+    cy.realPress(['Shift', 'Tab']);
+    cy.getId('btn-next-year').should('have.focus');
+    cy.realPress(['Shift', 'Tab']);
+    cy.getId('btn-next-month').should('have.focus');
+    cy.realPress(['Shift', 'Tab']);
+    cy.getId('btn-previous-month').should('have.focus');
+    cy.realPress(['Shift', 'Tab']);
+    cy.getId('btn-previous-year').should('have.focus');
+    cy.realPress(['Shift', 'Tab']);
+    cy.getId('btn-close').should('have.focus');
+    cy.realPress(['Shift', 'Tab']);
+    cy.getId('btn-day-2022-02-02').should('have.focus');
+    cy.realPress('Tab');
+    cy.getId('btn-close').should('have.focus');
+    cy.realPress('Tab');
+    cy.getId('btn-previous-year').should('have.focus');
+    cy.realPress('Tab');
+    cy.getId('btn-previous-month').should('have.focus');
+    cy.realPress('Tab');
+    cy.getId('btn-next-month').should('have.focus');
+    cy.realPress('Tab');
+    cy.getId('btn-next-year').should('have.focus');
+    cy.realPress('Tab');
+    cy.getId('btn-day-2022-02-02').should('have.focus');
+  });
+
   it('should tab from first button to the calendar and then to the last button', () => {
     cy.visitStory('tests--single-date-preselected');
     cy.getId('btn-focus-start').focus();

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -198,7 +198,7 @@ test('getNewDisplayTimePeriods', () => {
 });
 
 test('getUniqueId', () => {
-  expect(getUniqueId()).toEqual('rdhp-id-1');
+  expect(getUniqueId()).toEqual('rhdp-id-1');
   expect(getUniqueId('test')).toEqual('test2');
 });
 


### PR DESCRIPTION
Bug: getUniqueId had a typo in the generated id
New: id is now returned from getDatepickerContainerProps
New: useDatepicker now exports focusedDate, hoveredDate, and id
New: isDateValid now exported for testing dates outside of the datepicker