### PR TITLE
Fix bug where the month in which a min date or max date exist are not reachable if the current date is less than or greater than min/max date respectively

### DIFF
--- a/.stories/tests/Testing.stories.tsx
+++ b/.stories/tests/Testing.stories.tsx
@@ -4,6 +4,7 @@ import { isDateValid } from '../../src/util';
 import Datepicker from '../components/Datepicker';
 import BrokenDatepicker from '../components/BrokenDatepicker';
 import ChainDate, { TimePeriod } from '../../src/chain-date';
+import React from 'react';
 
 export default {
   title: 'Tests',
@@ -147,8 +148,8 @@ export const BlockedDates = () => {
   ]);
   const initialDate = new ChainDate('2021-11-09');
   const sixWeeks = 42;
-  const forwardDates = useRef([]);
-  const backDates = useRef([]);
+  const forwardDates = useRef<string[]>([]);
+  const backDates = useRef<string[]>([]);
 
   useEffect(() => {
     for (let i = 1; i <= sixWeeks; i += 1) {
@@ -164,8 +165,8 @@ export const BlockedDates = () => {
   }, []);
 
   const [selectDates, setSelectDates] = useState<SelectedDates>(initialDate.format());
-  const [maxDate, setMaxDate] = useState('2022-02-13');
-  const [minDate, setMinDate] = useState(null);
+  const [maxDate, setMaxDate] = useState<null | string>('2022-02-13');
+  const [minDate, setMinDate] = useState<null | string>(null);
   const [mode, setMode] = useState<DateSelectionMode>('single');
 
   const additionalControls = (
@@ -325,6 +326,13 @@ export const MaxDate = () => {
 
   const additionalControls = (
     <>
+    <button
+      className="btn btn-primary mr-1 my-1"
+      data-testid="btn-set-max-date-2021-12-01"
+      onClick={() => setMaxDate('2021-12-01')}
+    >
+      Set maxDate to 2021-12-01
+    </button>
       <button
         className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-max-date-2022-01-08"
@@ -370,6 +378,20 @@ export const MinDate = () => {
 
   const additionalControls = (
     <>
+    <button
+      className="btn btn-primary mr-1 my-1"
+      data-testid="btn-set-min-date-2021-11-01"
+      onClick={() => setMinDate('2021-11-01')}
+    >
+      Set minDate to 2021-11-01
+    </button>
+    <button
+      className="btn btn-primary mr-1 my-1"
+      data-testid="btn-set-min-date-2021-11-30"
+      onClick={() => setMinDate('2021-11-30')}
+    >
+      Set minDate to 2021-11-30
+    </button>
       <button
         className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-min-date-2021-08-08"
@@ -435,7 +457,7 @@ export const MinMaxDate = () => {
 };
 
 export const MultipleDatePreselected = () => {
-  const selectDates = ['2021-11-01', '2021-11-10', '2021-11-15', , '2021-11-25'];
+  const selectDates = ['2021-11-01', '2021-11-10', '2021-11-15', '2021-11-25'];
   const [datesSelected, setDatesSelected] = useState<SelectedDates>(selectDates);
 
   return (
@@ -642,14 +664,14 @@ export const SingleDatePreselected = () => {
       <button
         className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-month-february"
-        onClick={() => datepickerMethods.current.setMonth(2)}
+        onClick={() => datepickerMethods.current?.setMonth(2)}
       >
         Set Month to February
       </button>
       <button
         className="btn btn-primary mr-1 my-1"
         data-testid="btn-set-year-2024"
-        onClick={() => datepickerMethods.current.setYear(2024)}
+        onClick={() => datepickerMethods.current?.setYear(2024)}
       >
         Set Year to 2024
       </button>

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,9 @@ export interface CalendarDay {
 
 export type DatesMap = { [key: string]: null };
 
-export type DatepickerMethodsRef = MutableRefObject<{ setMonth(month: number): void; setYear(year: number): void }>;
+export type DatepickerMethodsRef = MutableRefObject<
+  { setMonth(month: number): void; setYear(year: number): void } | undefined
+>;
 
 export type DateSelectionMode = 'single' | 'range' | 'multiple' | number;
 
@@ -71,7 +73,7 @@ export enum RenderType {
   User,
 }
 
-export type SelectedDates = string | string[];
+export type SelectedDates = string | string[] | undefined | null;
 
 export interface UseDatepickerProps {
   blockedDates?: SelectedDates;
@@ -87,8 +89,8 @@ export interface UseDatepickerProps {
     today?: string;
   };
   locale?: string;
-  maxDate?: string;
-  minDate?: string;
+  maxDate?: string | null | undefined;
+  minDate?: string | null | undefined;
   mode?: DateSelectionMode;
   onChange?(newDates: SelectedDates): void;
   onClose?(): void;

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,7 +73,7 @@ export enum RenderType {
   User,
 }
 
-export type SelectedDates = string | string[] | undefined | null;
+export type SelectedDates = string | string[] | null | undefined;
 
 export interface UseDatepickerProps {
   blockedDates?: SelectedDates;

--- a/src/use-datepicker.ts
+++ b/src/use-datepicker.ts
@@ -775,6 +775,7 @@ export const useDatepicker = ({
           pageUpTimePeriod = TimePeriod.Year;
         }
         newFocusedDate = new ChainDate(dateToFocus).add(-1, pageUpTimePeriod, true).format();
+        // check if the minDate and newFocusedDate are in the same year/month e.g 2023-07
         if (minDate && newFocusedDate.substring(0, 7) === minDate.substring(0, 7) && minDate > newFocusedDate) {
           newFocusedDate = findBestDateToFocus(
             new ChainDate(dateToFocus).add(-1, pageUpTimePeriod, true).format(),
@@ -791,6 +792,7 @@ export const useDatepicker = ({
           pageDownTimePeriod = TimePeriod.Year;
         }
         newFocusedDate = new ChainDate(dateToFocus).add(1, pageDownTimePeriod, true).format();
+        // check if the maxDate and newFocusedDate are in the same year/month e.g 2023-07
         if (maxDate && newFocusedDate.substring(0, 7) === maxDate.substring(0, 7) && maxDate < newFocusedDate) {
           newFocusedDate = findBestDateToFocus(
             new ChainDate(dateToFocus).add(1, pageDownTimePeriod, true).format(),

--- a/src/util.ts
+++ b/src/util.ts
@@ -9,7 +9,10 @@ export const convertToStringArray = (maybeArray: SelectedDates): string[] => {
   if (Array.isArray(maybeArray)) {
     return maybeArray;
   }
-  return [maybeArray];
+  if (maybeArray) {
+    return [maybeArray];
+  }
+  return [];
 };
 
 export const formatDayOfTheWeek = (locale: string, date: Date, format: 'long' | 'short' | 'narrow' | undefined) => {
@@ -67,8 +70,11 @@ export function getUniqueId(prefix = 'rhdp-id-') {
   return `${prefix}${(uniqueId += 1)}`;
 }
 
-export const isDateValid = (date: string): boolean => {
+export const isDateValid = (date?: string | null): boolean => {
   try {
+    if (!date) {
+      return false;
+    }
     const [year, month, day] = date.match(/\d+/g) || ['', '', ''];
     const dateRegex = /^\d{4}-\d{2}-\d{2}$/u;
     const jsDate = new Date(`${prependZeroes(month, 2)}/${prependZeroes(day, 2)}/${year}`);

--- a/tests/cypress/integration/controls.spec.ts
+++ b/tests/cypress/integration/controls.spec.ts
@@ -97,9 +97,36 @@ describe('Previous month controls', () => {
     cy.getId('btn-day-2021-11-01').should('have.attr', 'aria-pressed', 'true');
     cy.getId('btn-previous-month').should('be.disabled');
   });
+
+  it('should allow clicking to the previous month if the min date is the last day of the month and they have already clicked into the next month', () => {
+    cy.visitStory('tests--min-date');
+    cy.getId('btn-day-2021-11-06').should('be.disabled');
+    cy.getId('btn-day-2021-11-07').should('not.be.disabled');
+    cy.getId('btn-set-min-date-2021-11-30').realClick();
+    cy.getId('btn-day-2021-11-30').should('not.be.disabled').realClick();
+    cy.getId('btn-day-2021-11-29').should('be.disabled');
+    cy.getId('div-month-year-title').contains('November 2021');
+    cy.getId('btn-next-month').realClick();
+    cy.getId('div-month-year-title').contains('December 2021');
+    cy.getId('btn-day-2021-12-01').realClick();
+    cy.getId('btn-previous-month').should('not.be.disabled').realClick();
+    cy.getId('div-month-year-title').contains('November 2021');
+    cy.getId('btn-day-2021-11-30').should('not.be.disabled');
+    cy.getId('btn-day-2021-11-29').should('be.disabled');
+  });
 });
 
 describe('Next month controls', () => {
+  it('should allow clicking to the next month if the max date is the first day of the month and the selected date in the current month is disabled in the next month', () => {
+    cy.visitStory('tests--max-date');
+    cy.getId('btn-set-max-date-2021-12-01').realClick();
+    cy.getId('btn-day-2021-11-02').should('not.be.disabled').realClick();
+    cy.getId('btn-day-2021-12-02').should('be.disabled');
+    cy.getId('div-month-year-title').contains('November 2021');
+    cy.getId('btn-next-month').realClick();
+    cy.getId('div-month-year-title').contains('December 2021');
+  });
+
   it('should go to the right month one month forward', () => {
     cy.visitStory('tests--single-date-preselected');
     cy.getId('div-month-year-title').contains('November 2021');
@@ -147,14 +174,23 @@ describe('Next month controls', () => {
 });
 
 describe('Controls when max multiple dates are all selected', () => {
-  it('should disable all month and year controls when all dates are selected in the same month', () => {
+  beforeEach(() => {
     cy.visitStory('tests--single-date-preselected');
+  });
+
+  const setTestConditions = () => {
+    cy.getId('btn-set-mode-max-3').click();
+    cy.getId('btn-set-select-dates-multiple').click();
+  };
+
+  it('should disable all month and year controls when all dates are selected in the same month', () => {
     cy.getId('btn-previous-month').should('not.be.disabled');
     cy.getId('btn-previous-year').should('not.be.disabled');
     cy.getId('btn-next-month').should('not.be.disabled');
     cy.getId('btn-next-year').should('not.be.disabled');
-    cy.getId('btn-set-mode-max-3').click();
-    cy.getId('btn-set-select-dates-multiple').click();
+
+    setTestConditions();
+
     cy.getId('btn-day-2021-11-01').should('be.visible');
     cy.getId('btn-previous-month').should('be.disabled');
     cy.getId('btn-previous-year').should('be.disabled');
@@ -163,6 +199,8 @@ describe('Controls when max multiple dates are all selected', () => {
   });
 
   it('should enable all controls when max multiple is not maxed out', () => {
+    setTestConditions();
+
     cy.getId('btn-day-2021-11-30')
       .should('have.attr', 'aria-pressed', 'true')
       .click()
@@ -174,6 +212,13 @@ describe('Controls when max multiple dates are all selected', () => {
   });
 
   it('should allow navigation between two consecutive months when selected dates are in both months', () => {
+    setTestConditions();
+
+    cy.getId('btn-day-2021-11-30')
+      .should('have.attr', 'aria-pressed', 'true')
+      .click()
+      .should('have.attr', 'aria-pressed', 'false');
+
     cy.getId('btn-day-2021-12-01').click();
     cy.getId('div-month-year-title').should('have.text', 'December 2021');
     cy.getId('btn-previous-month').should('not.be.disabled');
@@ -188,10 +233,18 @@ describe('Controls when max multiple dates are all selected', () => {
     cy.getId('btn-next-year').should('be.disabled');
     cy.getId('btn-next-month').click();
     cy.getId('div-month-year-title').should('have.text', 'December 2021');
+    cy.getId('btn-day-2021-12-01').should('have.attr', 'aria-pressed', 'true');
   });
 
   it('should allow navigation between two consecutive years when selected dates are in both years', () => {
-    cy.getId('btn-day-2021-12-01').should('have.attr', 'aria-pressed', 'true').click();
+    setTestConditions();
+
+    cy.getId('btn-day-2021-11-30')
+      .should('have.attr', 'aria-pressed', 'true')
+      .click()
+      .should('have.attr', 'aria-pressed', 'false');
+
+    cy.getId('btn-next-month').click();
     cy.getId('btn-next-year').click();
     cy.getId('div-month-year-title').should('have.text', 'December 2022');
     cy.getId('btn-day-2022-12-01').click();
@@ -200,16 +253,31 @@ describe('Controls when max multiple dates are all selected', () => {
     cy.getId('btn-next-month').should('be.disabled');
     cy.getId('btn-next-year').should('be.disabled');
     cy.getId('btn-previous-year').click();
-    cy.getId('div-month-year-title').should('have.text', 'December 2021');
-    cy.getId('btn-previous-month').should('not.be.disabled');
+    cy.getId('btn-previous-month').click();
+    cy.getId('div-month-year-title').should('have.text', 'November 2021');
+    cy.getId('btn-previous-month').should('be.disabled');
     cy.getId('btn-previous-year').should('be.disabled');
     cy.getId('btn-next-month').should('not.be.disabled');
     cy.getId('btn-next-year').should('not.be.disabled');
     cy.getId('btn-next-year').click();
+    cy.getId('div-month-year-title').should('have.text', 'November 2022');
+    cy.getId('btn-next-month').click();
     cy.getId('div-month-year-title').should('have.text', 'December 2022');
   });
 
   it('should allow navigation between all months between the range of selected dates', () => {
+    setTestConditions();
+
+    cy.getId('btn-day-2021-11-30')
+      .should('have.attr', 'aria-pressed', 'true')
+      .click()
+      .should('have.attr', 'aria-pressed', 'false');
+
+    cy.getId('btn-next-year').click();
+    cy.getId('btn-next-month').click();
+    cy.getId('div-month-year-title').should('have.text', 'December 2022');
+    cy.getId('btn-day-2022-12-01').click();
+
     cy.getId('btn-previous-month').click();
     cy.getId('div-month-year-title').should('have.text', 'November 2022');
     cy.getId('btn-previous-month').click();


### PR DESCRIPTION
 - Adds some tsdoc style documentation to a few methods
 - Fixes typescript issues
 - Adds stories/tests for the issue with the min and max date causing the month in which those dates occur to be unreachable depending on the actively focused date
 - Refactored some tests to be able to be run in isolation, a future Cypress upgrade is going to require this of all tests